### PR TITLE
Fix build by pinning Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 18
     - name: Install dependencies
       run: |
         sudo apt-get update


### PR DESCRIPTION
## Summary
- fix GitHub Actions build by setting up Node 18

## Testing
- `./server/run_tests.sh`
- `node client/test.js`


------
https://chatgpt.com/codex/tasks/task_e_685d88300eb88321ae6626d9ca82658a